### PR TITLE
Fix launching ioq3 on Linux

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,11 +27,12 @@ void ioLaunch::on_btnLaunch_clicked()
         path.replace(" ", "\" \"");
         ioq3 = path + "\\ioquake3.x86.exe +set r_mode -1";
     }
-
-#elif defined Q_OS_X11
-    ioq3 = "ioquake3 +set r_mode -1";
 #elif defined Q_OS_MAC
     ioq3 = "open -a ioquake3 --args +set r_mode -1";
+#elif defined Q_OS_UNIX
+    ioq3 = "ioquake3 +set r_mode -1";
+#else
+    #error "Unsupported platform"
 #endif
 
 


### PR DESCRIPTION
Q_OS_X11 does not exist (it was a Qt documentation error).
Q_OS_UNIX is also defined on Mac, so move Unix block after Mac.
There is a specific Q_OS_LINUX, but it's a general Unix style command.

Also added error message for unhandled platforms.
